### PR TITLE
Add debouncing to file change events

### DIFF
--- a/pkg/graph/manager_options.go
+++ b/pkg/graph/manager_options.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
@@ -116,4 +117,12 @@ func WithOutsideWorkDirFilter(m *manager) error {
 		return !strings.HasPrefix(pkg.Dir, m.workdir)
 	})
 	return nil
+}
+
+// WithDebounce configures the graph to debounce events by duration.
+func WithDebounce(debounce time.Duration) Option {
+	return func(m *manager) error {
+		m.debounce = debounce
+		return nil
+	}
 }

--- a/pkg/graph/manager_test.go
+++ b/pkg/graph/manager_test.go
@@ -612,11 +612,21 @@ func Echo() {
 		t.Errorf("writeFilesToGOPATH() = %v", err)
 	}
 
-	// Sleep because we build things up asynchronously.
-	time.Sleep(100 * time.Millisecond)
+	if err := writeFilesToGOPATH(workdir, newfiles); err != nil {
+		t.Errorf("writeFilesToGOPATH() = %v", err)
+	}
 
-	if called == 0 {
-		t.Error("Wanted the observer to get called, but saw no calls")
+	// Sleep because we build things up asynchronously.
+	time.Sleep(50 * time.Millisecond)
+
+	if called != 0 {
+		t.Error("Expected events to get debounced")
+	}
+
+	time.Sleep(defaultDebounce)
+
+	if called != 1 {
+		t.Errorf("Wanted the observer to get called once, but saw %d calls", called)
 	}
 
 	morenewfiles := map[string]string{


### PR DESCRIPTION
My editor triggers many fsnotify events when I save a file (for various
reasons). This adds debouncing so we don't trigger multiple events in
rapid succession.

We may also want to debounce on the observer side to help with e.g. git
pulls triggering dozens of observation events.

* Add WithDebounce option to debounce events from fsnotify.
* Add 100ms debounce to default options.